### PR TITLE
data source returns empty string if ipv6 is disabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,6 @@ resource "aws_security_group_rule" "endpoints_allow_ingress_tcp443_from_vpc_cidr
   to_port           = 443
   protocol          = "tcp"
   cidr_blocks       = [data.aws_vpc.selected.cidr_block]
-  ipv6_cidr_blocks  = data.aws_vpc.selected.ipv6_cidr_block != null ? [data.aws_vpc.selected.ipv6_cidr_block] : null
+  ipv6_cidr_blocks  = data.aws_vpc.selected.ipv6_cidr_block != "" ? [data.aws_vpc.selected.ipv6_cidr_block] : null
   security_group_id = aws_security_group.endpoints[count.index].id
 }


### PR DESCRIPTION
when a vpc with no ipv6 cidrs is provided, it fails with the error:

```
│ Error: "" is not a valid CIDR block: invalid CIDR address: 
│ 
│   with module.vpc.module.vpc_endpoints[0].aws_security_group_rule.endpoints_allow_ingress_tcp443_from_vpc_cidr[0],
│   on .terraform/modules/vpc.vpc_endpoints/main.tf line 37, in resource "aws_security_group_rule" "endpoints_allow_ingress_tcp443_from_vpc_cidr":
│   37:   ipv6_cidr_blocks  = data.aws_vpc.selected.ipv6_cidr_block != null ? [data.aws_vpc.selected.ipv6_cidr_block] : null
```

